### PR TITLE
Added support for Weight value on nodes in slurm.conf

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -189,3 +189,13 @@ options:
             "What type of SelectTypeParameters to use. The default value is
             CR_Core. Other possible values are CR_Core_Memory, CR_CPU, 
             CR_CPU_Memory, CR_Socket, CR_Socket_Memory"
+  node_weight_criteria:
+    type: string
+    default: none
+    description: >-
+            "What type of node criteria to use for setting weights on nodes.
+            By default all nodes have Weight=1. When it is preferable to
+            allocate for example smaller memory nodes for smaller jobs, low
+            weights should be assigned to smaller nodes. Setting this charm
+            option will automatically order and weigh the nodes in ascending
+            order. Allowed values are RealMemory, CPUs and CoresPerSocket."

--- a/src/lib/charms/slurm/controller.py
+++ b/src/lib/charms/slurm/controller.py
@@ -43,4 +43,41 @@ def is_active_controller():
     return leadership.leader_get('active_controller') == hookenv.local_unit()
 
 
+def set_node_weight_criteria(node_weight_criteria, nodes):
+
+    criteria_allowed = ['RealMemory', 'CPUs', 'CoresPerSocket']
+    if not node_weight_criteria in criteria_allowed:
+        hookenv.status_set('blocked', 'Incorrect charm "node_weight_criteria=%s" '
+                'configuration, aborting charm configuration!' % node_weight_criteria)
+        return False
+
+    weightsizes = {}
+    for n in nodes:
+        # Don't just assume the criteria is available for every node.
+        # If not, store lowest weight 1 (default anyway) so it will get the lowest weight
+        try:
+            hookenv.log('Saving %s=%s for node %s' %
+                    (node_weight_criteria, n['inventory'][node_weight_criteria], n['inventory']['NodeName']))
+            weightsizes[int(n['inventory'][node_weight_criteria])] = "x"
+        except KeyError as e:
+            hookenv.log('No %s value found for node %s, will set node weight 1' % (node_weight_criteria, n['inventory']['NodeName']))
+            weightsizes[1] = "x"
+
+    weightindex = 1
+    # note: sorted(weightsizes, reverse=True) is for reverse sorting, but does it really make
+    # sense to put weights in reverse order?
+    for size in sorted(weightsizes):
+        weightsizes[size] = weightindex
+        hookenv.log('Adding weight %d to %s=%d\n' % (weightindex, node_weight_criteria, size))
+        weightindex += 1
+
+    for n in nodes:
+        try:
+            n['inventory'].update({'Weight' : str(weightsizes[int(n['inventory'][node_weight_criteria])])})
+        except KeyError as e:
+            n['inventory'].update({'Weight' : '1'})
+
+    return True
+
+
 ROLES = {True: 'active_controller', False: 'backup_controller'}

--- a/src/reactive/slurm_controller.py
+++ b/src/reactive/slurm_controller.py
@@ -107,6 +107,16 @@ def configure_controller(*args):
     nodes = cluster_endpoint.get_node_data()
     partitions = controller.get_partitions(nodes)
 
+    # Implementation of automatic node weights
+    node_weight_criteria = hookenv.config().get('node_weight_criteria')
+    if node_weight_criteria != 'none':
+        weightres = controller.set_node_weight_criteria(node_weight_criteria, nodes)
+        # If the weight configuration is incorrect, abort reconfiguration. Status
+        # will be set to blocked with an informative message. The controller charm
+        # will keep running.
+        if not weightres:
+            return
+
     # relation-changed does not necessarily mean that data will be provided
     if not partitions:
         flags.clear_flag('endpoint.slurm-cluster.changed')


### PR DESCRIPTION
Modified the slurm.conf template in layer-slurm to include the Weight
parameter if the slurm-controller charm has been instructed to put
weight on nodes via the new node_weight_criteria charm option.

When it is preferable to allocate for example smaller memory nodes for
smaller jobs, low weights should be assigned to smaller nodes.
Configuring node_weight_criteria on the slurm-controller charm  will
automatically order and weigh the nodes in ascending order. Allowed
values are RealMemory, CPUs and CoresPerSocket.