### PR TITLE
Add timelimit option

### DIFF
--- a/src/lib/charms/slurm/controller.py
+++ b/src/lib/charms/slurm/controller.py
@@ -30,6 +30,7 @@ def get_partitions(node_data):
         part_dict[node['partition']].setdefault('hosts', [])
         part_dict[node['partition']]['hosts'].append(node['hostname'])
         part_dict[node['partition']]['default'] = node['default']
+        part_dict[node['partition']]['timelimit'] = node['timelimit']
     return dict(part_dict)
 
 


### PR DESCRIPTION
Slurm allows configuring timelimits for partitions. This PR implements that in the Juju gui. Accompanies PR in the https://github.com/omnivector-solutions/layer-slurm-node repository. 